### PR TITLE
Prevents JS errors in admin pages where Mailup elements are not visible

### DIFF
--- a/src/js/mailup/admin.js
+++ b/src/js/mailup/admin.js
@@ -8,6 +8,9 @@
  * Setup Ajax in system config for loading groups
  */
 function initListObserver(url) {
+    if ($('mailup_newsletter_mailup_list') == null) {
+        return;
+    }
     $('mailup_newsletter_mailup_list').observe('change', function (event) {
         var currentGroupSelected = $('mailup_newsletter_mailup_default_group').value;
         var updater = new Ajax.Updater('mailup_newsletter_mailup_default_group', url, {
@@ -21,6 +24,9 @@ function initListObserver(url) {
 }
 
 function initSelfTestObserver(url) {
+    if ($('mailup_selftest_button') == null) {
+        return;
+    }
     $('mailup_selftest_button').observe('click', function (event) {
         var request = new Ajax.Request(url, {
             method: 'get',


### PR DESCRIPTION
In some cases I have seen these observers causing problems in the admin. I can't reliably reproduce the issue, but this fix should solve the problem.