### PR TITLE
Prevents observer call when saving subscriber from webhook

### DIFF
--- a/src/app/code/local/MailUp/MailUpSync/Model/Observer.php
+++ b/src/app/code/local/MailUp/MailUpSync/Model/Observer.php
@@ -200,6 +200,10 @@ class MailUp_MailUpSync_Model_Observer
      */
     public function beforeSave($observer)
     {
+        if (isset($GLOBALS['__sl_mailup_save_from_webhook'])) {
+            return;
+        }
+
         $model = $observer->getEvent()->getDataObject();
 
         $confirm = Mage::getStoreConfig('mailup_newsletter/mailup/require_subscription_confirmation');
@@ -230,6 +234,10 @@ class MailUp_MailUpSync_Model_Observer
      */
 	public function sendUser($observer)
 	{
+        if (isset($GLOBALS['__sl_mailup_save_from_webhook'])) {
+            return $this;
+        }
+
         $model = $observer->getEvent()->getDataObject();
 
         // Ensure that (if called as singleton), this will only get called once per customer

--- a/src/app/code/local/MailUp/MailUpSync/controllers/WebhookController.php
+++ b/src/app/code/local/MailUp/MailUpSync/controllers/WebhookController.php
@@ -42,7 +42,7 @@ class MailUp_MailUpSync_WebhookController extends Mage_Core_Controller_Front_Act
             die();
         }
 
-        $GLOBALS["__sl_mailup_invia_utente"] = 1; //avoids observer
+        $GLOBALS['__sl_mailup_save_from_webhook'] = 1; //avoids observer
         $model
             ->setStatus(Mage_Newsletter_Model_Subscriber::STATUS_SUBSCRIBED)
             ->save();
@@ -88,7 +88,7 @@ class MailUp_MailUpSync_WebhookController extends Mage_Core_Controller_Front_Act
             die();
         }
 
-        $GLOBALS["__sl_mailup_invia_utente"] = 1; //avoids observer
+        $GLOBALS['__sl_mailup_save_from_webhook'] = 1; //avoids observer
         $model
             ->setStatus(Mage_Newsletter_Model_Subscriber::STATUS_UNSUBSCRIBED)
             ->save();


### PR DESCRIPTION
If the subscriber is saved from the Mailup webhook the observer
should not run (because MailUp has already with that status).

Indeed before this fix it's impossible to subscribe a subscriber
through MailUp's webhook.