### PR TITLE
MailUp leggiUtente workaround

### DIFF
--- a/src/app/code/local/MailUp/MailUpSync/Model/Observer.php
+++ b/src/app/code/local/MailUp/MailUpSync/Model/Observer.php
@@ -178,7 +178,7 @@ class MailUp_MailUpSync_Model_Observer
 						$model->setIsSubscribed(1);
 						$model->save();
 						break;
-					case "in attesa":
+					case "disiscritto": // MailUp ReportByUser currently says "Disiscritto" for unconfirmed and "In Attesa" for unsubscribed...
                         if ($subscriber && $subscriber->getId()) {
                             $subscriber->setStatus(Mage_Newsletter_Model_Subscriber::STATUS_UNCONFIRMED)->save();
                         }


### PR DESCRIPTION
MailUp ReportByUser SOAP method is bugged. It returns "In Attesa" for unsubscribed subscribers (but should say "Disiscritto"). And says "Disiscritto" for unconfirmed subscibers (but should say "In Attesa")...