### PR TITLE
Fix customer login event

### DIFF
--- a/src/app/code/local/MailUp/MailUpSync/Model/Observer.php
+++ b/src/app/code/local/MailUp/MailUpSync/Model/Observer.php
@@ -132,6 +132,7 @@ class MailUp_MailUpSync_Model_Observer
 	public function leggiUtente($observer)
 	{
 		$model = $observer->getEvent()->getModel();
+		if (empty($model)) $model = $model = $observer->getEvent()->getCustomer();
 		if (empty($model)) $model = $model = $observer->getEvent()->getDataObject();
 		if (isset($GLOBALS["__sl_mailup_leggi_utente"])) return $this;
 		$GLOBALS["__sl_mailup_leggi_utente"] = true;

--- a/src/app/code/local/MailUp/MailUpSync/etc/config.xml
+++ b/src/app/code/local/MailUp/MailUpSync/etc/config.xml
@@ -114,7 +114,7 @@
 					</mailupsenduser_observer>
 				</observers>
 			</newsletter_subscriber_save_after>
-			<customer_customer_authenticated>
+			<customer_login>
 				<observers>
 					<mailupleggiutente_observer>
 						<type>singleton</type>
@@ -122,7 +122,7 @@
 						<method>leggiUtente</method>
 					</mailupleggiutente_observer>
 				</observers>
-			</customer_customer_authenticated>
+			</customer_login>
 			<controller_action_postdispatch_adminhtml_system_config_save>
 				<observers>
 					<mailupconfigsave_observer>


### PR DESCRIPTION
When the customer_customer_authenticated event is fired the customer has not been put in session yet. This could lead to problems with subsequent observers that assume that the customer is logged in.
The customer_login event is instead fired just after the customer has been put in session.